### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-test: PHP := 8.3
+test: PHP := 8.5
 test: vendor
 	@echo "Run composer test (all tests)"
 	@docker run --rm -it --volume $$PWD:/app druidfi/drupal:php-$(PHP) composer test
 
-test-%: PHP := 8.3
+test-%: PHP := 8.5
 test-%: vendor
 	@echo "Run composer test-$*"
 	@docker run --rm -it --volume $$PWD:/app druidfi/drupal:php-$(PHP) composer test-$*
 
-test-upsun: PHP := 8.3
+test-upsun: PHP := 8.5
 test-upsun: vendor
 	@echo "Run composer test-upsun"
 	@docker run --rm -it --volume $$PWD:/app druidfi/drupal:php-$(PHP) composer test-upsun


### PR DESCRIPTION
## Summary

- Add PHP 8.5 to the GitHub Actions test matrix
- Update default PHP version in Makefile from 8.3 to 8.5

`composer.json` already declares `"php": "^8.1"` so no constraint change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)