### PR TITLE
Fix ConflictingHeadersException on generic reverse-proxy hosting

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -90,12 +90,16 @@ class Reader
         if ($_SERVER['REMOTE_ADDR'] !== $client_ip) {
           $settings['reverse_proxy'] = TRUE;
           $settings['reverse_proxy_addresses'] = (!empty($forwarded)) ? $forwarded : [$_SERVER['REMOTE_ADDR']];
+          // Do not also trust HEADER_FORWARDED here: Symfony throws
+          // ConflictingHeadersException if a request carries both a trusted
+          // "Forwarded" header and a trusted "X-Forwarded-*" header that
+          // disagree, which happens whenever a client sends its own spoofed
+          // "Forwarded" header through a proxy that only sets X-Forwarded-*.
           $settings['reverse_proxy_trusted_headers'] =
             Request::HEADER_X_FORWARDED_FOR |
             Request::HEADER_X_FORWARDED_HOST |
             Request::HEADER_X_FORWARDED_PORT |
-            Request::HEADER_X_FORWARDED_PROTO |
-            Request::HEADER_FORWARDED;
+            Request::HEADER_X_FORWARDED_PROTO;
         }
       }
     }


### PR DESCRIPTION
## Summary

- In the generic auto-detect branch of `Reader.php` (used when no known hosting system is detected, e.g. our own Traefik-fronted UpCloud hosts), `reverse_proxy_trusted_headers` trusted both `Request::HEADER_FORWARDED` and the individual `Request::HEADER_X_FORWARDED_*` headers at the same time.
- Symfony's `Request::getTrustedValues()` throws `ConflictingHeadersException` whenever a request carries both a trusted `Forwarded` header and a trusted `X-Forwarded-*` header whose derived values disagree.
- Traefik (and similar reverse proxies) only ever add `X-Forwarded-*` headers, never `Forwarded`. Since Traefik doesn't restrict which client IPs it trusts to set forwarding headers (no `forwardedHeaders.trustedIPs`), any external client can send its own `Forwarded` header straight through. Because Drupal trusted both header types, a mismatching client-supplied `Forwarded` header crashed the request.
- Found via a production incident on druidfi/reka (PR druidfi/reka#516's deploy is when it started surfacing): `ConflictingHeadersException` on essentially every request from clients sending a `Forwarded` header.

## Fix

Drop `Request::HEADER_FORWARDED` from the trusted header bitmask in the auto-detect branch, since it's never actually the header format these proxies use.

## Test plan

- [x] `php -l src/Reader.php`
- [ ] CI test suite (`make test`)